### PR TITLE
Normalize unicode

### DIFF
--- a/bundle/beta-code.js
+++ b/bundle/beta-code.js
@@ -7,7 +7,7 @@ var unicode_to_beta_code = require('./vendor/beta-code-json/unicode_to_beta_code
 var max_beta_code_character_length = _longestKeyLength(beta_code_to_unicode);
 
 function greekToBetaCode (greek) {
-  var greek_characters = greek.split('');
+  var greek_characters = _normalize(greek).split('');
   var beta_code_characters = [];
   var current_character, ii;
 
@@ -25,7 +25,7 @@ function greekToBetaCode (greek) {
 }
 
 function betaCodeToGreek (beta_code) {
-  var beta_code_characters = beta_code.split('');
+  var beta_code_characters = _normalize(beta_code).split('');
   var greek_characters = [];
   var start = 0;
   var end, slice, new_start, current_character, max_length;
@@ -90,6 +90,14 @@ function _sigmaToEndOfWordSigma (string) {
 
 function _min (a, b) {
   return a < b ? a : b;
+}
+
+function _normalize (string) {
+  if (string.normalize) {
+    return string.normalize();
+  }
+
+  return string;
 }
 })();
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var unicode_to_beta_code = require('./vendor/beta-code-json/unicode_to_beta_code
 var max_beta_code_character_length = _longestKeyLength(beta_code_to_unicode);
 
 function greekToBetaCode (greek) {
-  var greek_characters = greek.split('');
+  var greek_characters = _normalize(greek).split('');
   var beta_code_characters = [];
   var current_character, ii;
 
@@ -24,7 +24,7 @@ function greekToBetaCode (greek) {
 }
 
 function betaCodeToGreek (beta_code) {
-  var beta_code_characters = beta_code.split('');
+  var beta_code_characters = _normalize(beta_code).split('');
   var greek_characters = [];
   var start = 0;
   var end, slice, new_start, current_character, max_length;
@@ -89,5 +89,13 @@ function _sigmaToEndOfWordSigma (string) {
 
 function _min (a, b) {
   return a < b ? a : b;
+}
+
+function _normalize (string) {
+  if (string.normalize) {
+    return string.normalize();
+  }
+
+  return string;
 }
 })();

--- a/test/test.js
+++ b/test/test.js
@@ -32,6 +32,13 @@ describe('#greekToBetaCode', function() {
 
     expect(bc.greekToBetaCode(greek)).to.equal(beta_code);
   });
+
+  it('should normalize the Unicode', function () {
+    var greek = 'Πολλὴ μὲν ἐν βροτοῖσι κοὐκ ἀνώνυμος θεὰ κέκλημαι Κύπρις οὐρανοῦ τ᾿ ἔσω·';
+    var beta_code = '*pollh\\ me\\n e)n brotoi=si kou)k a)nw/numos qea\\ ke/klhmai *ku/pris ou)ranou= t᾿ e)/sw:';
+
+    expect(bc.greekToBetaCode(greek)).to.equal(beta_code);
+  });
 });
 
 describe('#betaCodeToGreek', function() {


### PR DESCRIPTION
Normalize the unicode before converting to beta code. Some characters have multiple unicode representations, so this will make sure they're all converted correctly.